### PR TITLE
New console input\output and Java options replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Default memory setting is 4GB, to change edit `minecraft_java.env` and update `J
 
 Commands are passed to the server via the provided script `minecraft-console.py`.
 
-To run commands, open console by running `minecraft-console`. After executing the command, you will see the server log from `journalctl` and a prompt to enter the command.
+To run commands, open console by running `minecraft-console`. 
+After executing the command, you will see the server log from `journalctl` and a prompt to enter the command.
 To exit the console, press CTRL+C
 
 <sub>*Note:* Do not use / before the command name</sub>

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ git clone https://github.com/AtomicSponge/paper-systemd.git
 cd paper-systemd
 ```
 
-Place the file `minecraft` in `/usr/local/bin` and make sure it has execute permissions by running:
+Create link of file `minecraft-console.py` in `/usr/local/bin` and make sure it has execute permissions by running:
 ```
-chmod 555 minecraft
-sudo mv minecraft /usr/local/bin
+chmod 555 minecraft-console.py
+sudo ln minecraft-console.py /usr/local/bin
 ```
 
 Place files `minecraft.service` and `minecraft.socket` in `/etc/systemd/system`:
@@ -64,19 +64,17 @@ sudo systemctl enable minecraft
 
 ## Memory Setting
 
-Default memory setting is 4GB, to change edit `minecraft.service` and update the following under `ExecStart` to your desired values:
+Default memory setting is 4GB, to change edit `minecraft_java.env` and update `JAVA_OPTS` to your desired values::
 ```
 -Xms4096M -Xmx4096M
 ```
 
 ## Usage
 
-Commands are passed to the server via the provided script.
+Commands are passed to the server via the provided script `minecraft-console.py`.
 
-To run commands, enter the server command after `minecraft`:
-```
-minecraft kick PlayerName
-```
+To run commands, open console by running `minecraft-console`. After executing the command, you will see the server log from `journalctl` and a prompt to enter the command.
+To exit the console, press CTRL+C
 
 <sub>*Note:* Do not use / before the command name</sub>
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Default memory setting is 4GB, to change edit `minecraft_java.env` and update `J
 Commands are passed to the server via the provided script `minecraft-console.py`.
 
 To run commands, open console by running `minecraft-console`. 
+
 After executing the command, you will see the server log from `journalctl` and a prompt to enter the command.
+
 To exit the console, press CTRL+C
 
 <sub>*Note:* Do not use / before the command name</sub>

--- a/minecraft-console.py
+++ b/minecraft-console.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+import curses
+import subprocess
+import threading
+
+def run_journalctl(win):
+    process = subprocess.Popen(['journalctl', '-u', 'minecraft', '--follow'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    while True:
+        line = process.stdout.readline()
+        if not line:
+            break
+        win.addstr(line.decode())
+        win.refresh()
+
+def input_commands(win):
+    with open('/run/minecraft.stdin', 'a') as f:
+        while True:
+            win.clear()
+            win.addstr("Enter  command (Ctrl-C to exit): ")
+            curses.echo()
+            win.move(1, 0)
+            command = win.getstr().decode()
+            f.write(command + "\n")
+            f.flush()
+            curses.noecho()
+            win.clear()
+
+def main(stdscr):
+    try:
+        curses.curs_set(1)
+        stdscr.clear()
+        
+        height, width = stdscr.getmaxyx()
+        journal_height = int(height * 0.9)
+        input_height = height - journal_height
+
+        journal_win = stdscr.subwin(journal_height, width, 0, 0)
+        journal_win.scrollok(True)
+        input_win = stdscr.subwin(input_height, width, journal_height, 0)
+
+        thread = threading.Thread(target=run_journalctl, args=(journal_win,))
+        thread.daemon = True
+        thread.start()
+
+        input_commands(input_win)
+        
+    except KeyboardInterrupt:
+        stdscr.clear()
+        stdscr.refresh()
+    finally:
+        curses.endwin()
+
+if __name__ == "__main__":
+    curses.wrapper(main)

--- a/minecraft.service
+++ b/minecraft.service
@@ -4,7 +4,8 @@ Description=Minecraft Server
 [Service]
 Type=simple
 WorkingDirectory=/home/minecraft/paper
-ExecStart=java -Xms4096M -Xmx4096M -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -XX:+PerfDisableSharedMem -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:G1HeapWastePercent=5 -XX:G1MaxNewSizePercent=40 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1NewSizePercent=30 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=15 -XX:MaxGCPauseMillis=200 -XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=32 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar /home/minecraft/paper/server.jar nogui
+EnvironmentFile=/home/minecraft/paper/minecraft_java.env
+ExecStart=java $JAVA_OPTS -jar /home/minecraft/paper/server.jar nogui
 ExecStop=echo "stop" > /run/minecraft.stdin
 User=minecraft
 Restart=on-failure

--- a/minecraft_java.env
+++ b/minecraft_java.env
@@ -1,4 +1,4 @@
-JAVA_OPTS="-Xms8192M -Xmx8192M \
+JAVA_OPTS="-Xms4G -Xmx4G \
 -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -XX:+PerfDisableSharedMem \
 -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:G1HeapWastePercent=5 \
 -XX:G1MaxNewSizePercent=40 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 \

--- a/minecraft_java.env
+++ b/minecraft_java.env
@@ -1,0 +1,8 @@
+JAVA_OPTS="-Xms8192M -Xmx8192M \
+-XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -XX:+PerfDisableSharedMem \
+-XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:G1HeapWastePercent=5 \
+-XX:G1MaxNewSizePercent=40 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 \
+-XX:G1NewSizePercent=30 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:G1ReservePercent=20 \
+-XX:InitiatingHeapOccupancyPercent=15 -XX:MaxGCPauseMillis=200 \
+-XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=32 -Dusing.aikars.flags=https://mcflags.emc.gs \
+-Daikars.new.flags=true"


### PR DESCRIPTION
1. JAVA options have been moved to an env file to prevent use of `systemctl daemon-reload` after changing Java startup options.
2. Created python-script that combines server log output from `journalctl` and command input  from `minecraft`  bash-script
![python-minecraft-console](https://github.com/user-attachments/assets/0410a419-6658-4c28-b2dd-6d714f1bb141)
3. README  update


